### PR TITLE
Pandoc 2.0 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ epub: typeclassopedia.epub
 pdf: typeclassopedia.pdf
 
 typeclassopedia.epub: typeclassopedia.md
-	pandoc -s -S typeclassopedia.md \
+	pandoc -s -f markdown+smart typeclassopedia.md \
 		--epub-metadata=metadata.xml \
 		--epub-cover-image=cover.png \
 		-o typeclassopedia.epub
@@ -14,4 +14,4 @@ typeclassopedia.pdf: typeclassopedia.md
 	sed 's/^The type classes we will be discussing/\\clearpage &/' \
 		typeclassopedia.md|\
 		sed 's/Typeclassopedia-diagram.svg/Typeclassopedia-diagram.png/'| \
-		pandoc -s -S -o typeclassopedia.pdf
+		pandoc -s -f markdown+smart -o typeclassopedia.pdf


### PR DESCRIPTION
```
--smart/-S has been removed.  Use +smart or -smart extension instead.
For example: pandoc -f markdown+smart -t markdown-smart.
Try pandoc --help for more information.
```